### PR TITLE
Allow pngcopy to read from stdin if the special filename '-' is supplied

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .DS_Store
 *.dSYM/
 pngpaste
+pngcopy


### PR DESCRIPTION
This puts pngcopy closer to feature parity with pngpaste. Also in this request I added pngcopy to the .gitignore.